### PR TITLE
Fix filter_dictionary falsy value handling

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+Changelog 3.0.63
+[BUG] preserve falsy values in filter_dictionary
+
 Changelog 3.0.62
 [BUG] Optimised RD fix implementation
 [BUG] Improved RD season pack handling

--- a/resources/lib/common/tools.py
+++ b/resources/lib/common/tools.py
@@ -590,16 +590,25 @@ def merge_dicts(*dict_args):
 
 
 def filter_dictionary(dictionary, *keys):
-    """Filters the dictionary with the supplied args
+    """Filters ``dictionary`` retaining only the supplied keys.
 
-    :param dictionary:Dictionary to filter
-    :type dictionary:dict
-    :param keys:Keys to filter on
-    :type keys:any
-    :return:Filtered dictionary
-    :rtype:dict
+    This function previously omitted keys when their value evaluated to
+    ``False`` (for example ``0`` or ``""``) due to using the value in the
+    comprehension's condition.  The implementation has been adjusted so that
+    all existing keys are returned regardless of the truthiness of their
+    values.
+
+    :param dictionary: Dictionary to filter
+    :type dictionary: dict
+    :param keys: Keys to retain in the returned dictionary
+    :type keys: Any
+    :return: Filtered dictionary or ``None`` if ``dictionary`` is falsy
+    :rtype: dict | None
     """
-    return {k: v for k in keys if (v := dictionary.get(k))} if dictionary else None
+    if not dictionary:
+        return None
+
+    return {k: dictionary[k] for k in keys if k in dictionary}
 
 
 def safe_dict_get(dictionary, *path):


### PR DESCRIPTION
## Summary
- fix `filter_dictionary` so keys with falsy values aren't dropped
- document change in changelog

## Testing
- `python -m py_compile seren.py service.py $(find resources -name '*.py' | tr '\n' ' ')`

------
https://chatgpt.com/codex/tasks/task_e_6861d2682594832fbdd077146b2d7c70